### PR TITLE
Rewrite of player

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build: ## Make binary
 .PHONY: test
 test: ## Launch unit tests
 	@echo -e "$(OK_COLOR)[$(APP)] Launch unit tests $(NO_COLOR)"
-	@govendor test -timeout 1m -v +local
+	@govendor test -timeout 1m -cover -race +local
 
 .PHONY: release
 release: test build ## Make a release

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build: ## Make binary
 .PHONY: test
 test: ## Launch unit tests
 	@echo -e "$(OK_COLOR)[$(APP)] Launch unit tests $(NO_COLOR)"
-	@govendor test +local
+	@govendor test -timeout 1m -v +local
 
 .PHONY: release
 release: test build ## Make a release

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,10 +42,11 @@ const (
 )
 
 var (
-	vers   bool
-	debug  bool
-	lastFM bool
-	useGPM bool
+	vers         bool
+	debug        bool
+	lastFM       bool
+	useGPM       bool
+	experimental bool
 )
 
 func init() {
@@ -54,6 +55,7 @@ func init() {
 	flag.BoolVar(&debug, "debug", false, "debug")
 	flag.BoolVar(&lastFM, "lastfm", false, "Enable LastFM scrobbler")
 	flag.BoolVar(&useGPM, "googlemusic", false, "Use Google Play Music")
+	flag.BoolVar(&experimental, "experimental", false, "Use experimental features")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, fmt.Sprintf(BANNER, version.Version))
@@ -61,6 +63,13 @@ func init() {
 	}
 
 	flag.Parse()
+
+	if experimental {
+		jamsonic.Experimental = true
+	}
+	if debug {
+		jamsonic.Debug = true
+	}
 
 	if vers {
 		fmt.Printf("%s\n", version.Version)

--- a/config.go
+++ b/config.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 Joakim Kennedy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package jamsonic
+
+var Experimental = false
+var Debug = false

--- a/native/output_linux.go
+++ b/native/output_linux.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, 2017 Evgeny Badin
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// +build linux
+
+package native
+
+import (
+	"fmt"
+
+	pulse "github.com/mesilliac/pulse-simple"
+)
+
+type linuxOutputStream struct {
+	Stream *pulse.Stream
+}
+
+func init() {
+	makeOutputStream = func() (OutputStream, error) {
+		ss := pulse.SampleSpec{pulse.SAMPLE_S16LE, 44100, 2}
+		stream, err := pulse.Playback("jamsonic", "jamsonic", &ss)
+		if err != nil {
+			return nil, fmt.Errorf("Can't playback from Pulse: %s", err)
+		}
+		return &linuxOutputStream{
+			Stream: stream,
+		}, nil
+	}
+}
+
+func (los *linuxOutputStream) CloseStream() error {
+	los.Stream.Free()
+	if err := los.Stream.Drain(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (los *linuxOutputStream) Write(data []byte) (int, error) {
+	return los.Stream.Write(data)
+}

--- a/native/output_portaudio.go
+++ b/native/output_portaudio.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2018 Joakim Kennedy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// +build darwin
+
+package native
+
+import (
+	"bytes"
+	"encoding/binary"
+	"log"
+
+	"github.com/gordonklaus/portaudio"
+)
+
+const (
+	numInputChans    = 0
+	numOutputChans   = 2
+	sampleRate       = 44100
+	outputBufferSize = 8192 / 2
+)
+
+// portaudioOutputStream implements the OutputStream interface and
+// the io.WriteCloser interface.
+type portaudioOutputStream struct {
+	stream *portaudio.Stream
+	buf    []int16
+}
+
+func init() {
+	makeOutputStream = func() (OutputStream, error) {
+		out := &portaudioOutputStream{buf: make([]int16, outputBufferSize)}
+		if err := portaudio.Initialize(); err != nil {
+			return nil, err
+		}
+		stream, err := portaudio.OpenDefaultStream(
+			numInputChans, numOutputChans, float64(sampleRate), len(out.buf), out.buf)
+		if err != nil {
+			return nil, err
+		}
+		out.stream = stream
+		if err := stream.Start(); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
+// CloseStream closes the stream.
+func (p *portaudioOutputStream) CloseStream() error {
+	return p.Close()
+}
+
+// Close closes the stream.
+func (p *portaudioOutputStream) Close() error {
+	defer portaudio.Terminate()
+	p.buf = make([]int16, 0)
+	p.stream.Stop()
+	if err := p.stream.Close(); err != nil {
+		p.stream = nil
+		return err
+	}
+	p.stream = nil
+	return nil
+}
+
+// Write writes the data to portaudio's audio interface.
+func (p *portaudioOutputStream) Write(data []byte) (int, error) {
+	err := binary.Read(bytes.NewBuffer(data), binary.LittleEndian, p.buf)
+	if err != nil {
+		log.Println("Read error:", err.Error())
+		return 0, err
+	}
+	err = p.stream.Write()
+
+	// From portaudio docs:
+	// On success PaNoError will be returned, or paOutputUnderflowed if
+	// additional output data was inserted after the previous call and
+	// before this call.
+	if err == portaudio.OutputUnderflowed {
+		// Handle the error since the player doesn't know what to do with it.
+		err = nil
+	}
+	return outputBufferSize, err
+}

--- a/native/output_portaudio_test.go
+++ b/native/output_portaudio_test.go
@@ -23,6 +23,7 @@
 package native
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,13 @@ import (
 
 func TestPortaudio(t *testing.T) {
 	assert := assert.New(t)
+
+	// For some reason calling CloseStream on Travis panics.
+	// Skip these tests on Travis.
+	if os.Getenv("$TRAVIS_OS_NAME") == "osx" {
+		return
+	}
+
 	t.Run("should create outputstream and close", func(t *testing.T) {
 		out, err := makeOutputStream()
 		assert.NoError(err, "makeOutputStream should not fail")

--- a/native/output_portaudio_test.go
+++ b/native/output_portaudio_test.go
@@ -34,7 +34,7 @@ func TestPortaudio(t *testing.T) {
 
 	// For some reason calling CloseStream on Travis panics.
 	// Skip these tests on Travis.
-	if os.Getenv("$TRAVIS_OS_NAME") == "osx" {
+	if os.Getenv("TRAVIS_GO_VERSION") != "" {
 		t.SkipNow()
 	}
 

--- a/native/output_portaudio_test.go
+++ b/native/output_portaudio_test.go
@@ -35,7 +35,7 @@ func TestPortaudio(t *testing.T) {
 	// For some reason calling CloseStream on Travis panics.
 	// Skip these tests on Travis.
 	if os.Getenv("$TRAVIS_OS_NAME") == "osx" {
-		return
+		t.SkipNow()
 	}
 
 	t.Run("should create outputstream and close", func(t *testing.T) {

--- a/native/output_portaudio_test.go
+++ b/native/output_portaudio_test.go
@@ -38,14 +38,16 @@ func TestPortaudio(t *testing.T) {
 		assert.NotNil(out, "Output stream should not be nil")
 	})
 
-	t.Run("write bytes", func(t *testing.T) {
-		buf := make([]byte, inputBufferSize)
-		_, err = out.Write(buf)
-		assert.NoError(err, "Should write without error")
-	})
-
 	t.Run("should close without error", func(t *testing.T) {
 		err = out.CloseStream()
 		assert.NoError(err, "Should close without error")
+	})
+
+	t.Run("write bytes", func(t *testing.T) {
+		w, err := makeOutputStream()
+		assert.NoError(err, "Should not fail")
+		buf := make([]byte, inputBufferSize)
+		_, err = w.Write(buf)
+		assert.NoError(err, "Should write without error")
 	})
 }

--- a/native/output_portaudio_test.go
+++ b/native/output_portaudio_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 Joakim Kennedy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// +build darwin
+
+package native
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPortaudio(t *testing.T) {
+	assert := assert.New(t)
+	var out OutputStream
+	var err error
+	t.Run("should create outputstream", func(t *testing.T) {
+		out, err = makeOutputStream()
+		assert.NoError(err, "makeOutputStream should not fail")
+		assert.NotNil(out, "Output stream should not be nil")
+	})
+
+	t.Run("write bytes", func(t *testing.T) {
+		buf := make([]byte, inputBufferSize)
+		_, err = out.Write(buf)
+		assert.NoError(err, "Should write without error")
+	})
+
+	t.Run("should close without error", func(t *testing.T) {
+		err = out.CloseStream()
+		assert.NoError(err, "Should close without error")
+	})
+}

--- a/native/output_portaudio_test.go
+++ b/native/output_portaudio_test.go
@@ -30,15 +30,10 @@ import (
 
 func TestPortaudio(t *testing.T) {
 	assert := assert.New(t)
-	var out OutputStream
-	var err error
-	t.Run("should create outputstream", func(t *testing.T) {
-		out, err = makeOutputStream()
+	t.Run("should create outputstream and close", func(t *testing.T) {
+		out, err := makeOutputStream()
 		assert.NoError(err, "makeOutputStream should not fail")
 		assert.NotNil(out, "Output stream should not be nil")
-	})
-
-	t.Run("should close without error", func(t *testing.T) {
 		err = out.CloseStream()
 		assert.NoError(err, "Should close without error")
 	})
@@ -49,5 +44,6 @@ func TestPortaudio(t *testing.T) {
 		buf := make([]byte, inputBufferSize)
 		_, err = w.Write(buf)
 		assert.NoError(err, "Should write without error")
+		w.CloseStream()
 	})
 }

--- a/native/output_windows.go
+++ b/native/output_windows.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2017 Evgeny Badin
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// +build windows
+
+package native
+
+import (
+	"fmt"
+
+	"github.com/koron/go-waveout"
+)
+
+type windowsOutputStream struct {
+	Player *waveout.Player
+}
+
+func init() {
+	makeOutputStream = func() (OutputStream, error) {
+		player, err := waveout.NewWithBuffers(2, 44100, 16, 8, 4096)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create waveout: %s", err)
+		}
+		return &windowsOutputStream{
+			Player: player,
+		}, nil
+	}
+}
+
+func (wos *windowsOutputStream) CloseStream() error {
+	return wos.Player.Close()
+}
+
+func (wos *windowsOutputStream) Write(data []byte) (int, error) {
+	return wos.Player.Write(data)
+}

--- a/native/player.go
+++ b/native/player.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2018 Joakim Kennedy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package native
+
+import (
+	"io"
+	"sync"
+
+	"github.com/korandiz/mpa"
+)
+
+var (
+	inputBufferSize = 1024 * 8
+)
+
+var makeOutputStream func() (OutputStream, error)
+
+// OutputStream define an output stream
+type OutputStream interface {
+	CloseStream() error
+	Write(data []byte) (int, error)
+}
+
+type StreamHandler struct {
+	writer       OutputStream
+	writerMu     sync.Mutex
+	reader       io.Reader
+	FinishedChan chan struct{}
+	stopChan     chan struct{}
+	newTrackChan chan *io.Reader
+	ErrChan      chan error
+	pauseChan    chan struct{}
+	continueChan chan struct{}
+}
+
+func New() *StreamHandler {
+	return &StreamHandler{
+		FinishedChan: make(chan struct{}),
+		stopChan:     make(chan struct{}),
+		newTrackChan: make(chan *io.Reader),
+		ErrChan:      make(chan error),
+		pauseChan:    make(chan struct{}),
+		continueChan: make(chan struct{}),
+	}
+}
+
+func (p *StreamHandler) closeOutput() {
+	p.writerMu.Lock()
+	defer p.writerMu.Unlock()
+	p.writer.CloseStream()
+	p.writer = nil
+}
+
+func (p *StreamHandler) Play(stream io.Reader) error {
+	p.writerMu.Lock()
+	defer p.writerMu.Unlock()
+	// Nothing playing
+	if p.writer == nil {
+		writer, err := makeOutputStream()
+		if err != nil {
+			return err
+		}
+		p.writer = writer
+		go mainLoop(p, stream)
+	} else {
+		// Already playing a track, telling to switch stream.
+		p.newTrackChan <- &stream
+	}
+	return nil
+}
+
+func mainLoop(p *StreamHandler, stream io.Reader) {
+	defer p.closeOutput()
+	p.reader = newDecoder(&stream)
+	buf := make([]byte, inputBufferSize)
+	for {
+		select {
+		// Stop playing
+		case <-p.stopChan:
+			return
+		// Pause
+		case <-p.pauseChan:
+			select {
+			case <-p.continueChan:
+				continue
+			case <-p.stopChan:
+				return
+			case r := <-p.newTrackChan:
+				p.reader = newDecoder(r)
+				continue
+			}
+		// New stream
+		case r := <-p.newTrackChan:
+			p.reader = newDecoder(r)
+		// Play
+		default:
+			_, err := p.reader.Read(buf)
+			if err == io.EOF {
+				// Finished with this Track. Tell controller we are done.
+				p.FinishedChan <- struct{}{}
+				select {
+				// New track
+				case r := <-p.newTrackChan:
+					p.reader = newDecoder(r)
+					continue
+				case <-p.stopChan:
+					return
+				}
+			} else if err != nil {
+				p.ErrChan <- err
+				return
+			}
+			_, err = p.writer.Write(buf)
+			if err != nil {
+				p.ErrChan <- err
+				return
+			}
+		}
+	}
+}
+
+func (p *StreamHandler) Stop() {
+	p.stopChan <- struct{}{}
+}
+
+func (p *StreamHandler) Pause() {
+	p.pauseChan <- struct{}{}
+}
+
+func (p *StreamHandler) Continue() {
+	p.continueChan <- struct{}{}
+}
+
+var newDecoder func(*io.Reader) io.Reader = func(r *io.Reader) io.Reader {
+	return &mpa.Reader{Decoder: &mpa.Decoder{Input: *r}}
+}

--- a/native/player_test.go
+++ b/native/player_test.go
@@ -1,0 +1,271 @@
+package native
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlayer(t *testing.T) {
+	assert := assert.New(t)
+	// Ignore decoding the stream
+	newDecoder = func(r *io.Reader) io.Reader { return *r }
+	inputBufferSize = 1
+
+	t.Run("play full stream", func(t *testing.T) {
+		expectedContent := []byte{0x1, 0x2, 0x3, 0x4}
+		recorder := new(bytes.Buffer)
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) { return recorder.Write(b) },
+			doClose: func() error { return nil },
+		}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+		handler := New()
+		handler.Play(bytes.NewBuffer([]byte(expectedContent)))
+		<-handler.FinishedChan
+		handler.Stop()
+		data := recorder.Bytes()
+		assert.Equal(expectedContent, data, "Incorrect content returned.")
+	})
+
+	t.Run("play two full stream", func(t *testing.T) {
+		expectedContent1 := []byte{0x1, 0x2, 0x3, 0x4}
+		expectedContent2 := []byte{0x5, 0x6, 0x7, 0x8}
+		recorder := new(bytes.Buffer)
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) { return recorder.Write(b) },
+			doClose: func() error { return nil },
+		}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+		handler := New()
+		handler.Play(bytes.NewBuffer([]byte(expectedContent1)))
+		<-handler.FinishedChan
+		handler.Play(bytes.NewBuffer([]byte(expectedContent2)))
+		<-handler.FinishedChan
+		handler.Stop()
+		data := recorder.Bytes()
+		expectedContent := append(expectedContent1, expectedContent2...)
+		assert.Equal(expectedContent, data, "Incorrect content returned.")
+	})
+
+	t.Run("handle pause and resume", func(t *testing.T) {
+		expectedContent := []byte{0x1, 0x2, 0x3, 0x4}
+		wait := make(chan struct{})
+		handler := New()
+		recorder := new(bytes.Buffer)
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) {
+				if b[0] == 0x2 {
+					n, err := recorder.Write(b)
+					go handler.Pause()
+					wait <- struct{}{}
+					time.Sleep(time.Microsecond * 10)
+					return n, err
+				}
+				return recorder.Write(b)
+			},
+			doClose: func() error { return nil }}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+		handler.Play(bytes.NewBuffer(expectedContent))
+		<-wait
+		raw1 := recorder.Bytes()
+		handler.Continue()
+		<-handler.FinishedChan
+		handler.Stop()
+		raw2 := recorder.Bytes()
+		assert.Equal(expectedContent[:2], raw1, "Wrong content at the pause point")
+		assert.Equal(expectedContent, raw2, "Incorrect content returned.")
+	})
+	t.Run("handle pause and stop", func(t *testing.T) {
+		expectedContent := []byte{0x1, 0x2, 0x3, 0x4}
+		wait := make(chan struct{})
+		handler := New()
+		recorder := new(bytes.Buffer)
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) {
+				if b[0] == 0x2 {
+					n, err := recorder.Write(b)
+					go handler.Pause()
+					wait <- struct{}{}
+					time.Sleep(time.Microsecond * 10)
+					<-wait
+					return n, err
+				}
+				return recorder.Write(b)
+			},
+			doClose: func() error { return nil }}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+		handler.Play(bytes.NewBuffer(expectedContent))
+		<-wait
+		raw1 := recorder.Bytes()
+		wait <- struct{}{}
+		time.Sleep(time.Microsecond * 10)
+		go handler.Stop()
+		time.Sleep(time.Microsecond * 10)
+		raw2 := recorder.Bytes()
+		assert.Equal(expectedContent[:2], raw1, "Wrong content at the pause point")
+		assert.Equal(expectedContent[:2], raw2, "Incorrect content returned.")
+	})
+	t.Run("handle pause and play new stream", func(t *testing.T) {
+		expectedContent1 := []byte{0x1, 0x2, 0x3, 0x4}
+		expectedContent2 := []byte{0x5, 0x6, 0x7, 0x8}
+		wait := make(chan struct{})
+		handler := New()
+		recorder := new(bytes.Buffer)
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) {
+				if b[0] == 0x2 {
+					n, err := recorder.Write(b)
+					go handler.Pause()
+					wait <- struct{}{}
+					time.Sleep(time.Microsecond * 10)
+					<-wait
+					return n, err
+				}
+				return recorder.Write(b)
+			},
+			doClose: func() error { return nil }}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+		handler.Play(bytes.NewBuffer(expectedContent1))
+		<-wait
+		raw1 := recorder.Bytes()
+		wait <- struct{}{}
+		time.Sleep(time.Microsecond * 10)
+		go handler.Play(bytes.NewBuffer(expectedContent2))
+		<-handler.FinishedChan
+		raw2 := recorder.Bytes()
+		expectedFinalContent := expectedContent1[:2]
+		expectedFinalContent = append(expectedFinalContent, expectedContent2...)
+		assert.Equal(expectedContent1[:2], raw1, "Wrong content at the pause point")
+		assert.Equal(expectedFinalContent, raw2, "Incorrect content returned.")
+	})
+	t.Run("handle stop", func(t *testing.T) {
+		expectedContent := []byte{0x1, 0x2, 0x3, 0x4}
+		wait := make(chan struct{})
+		handler := New()
+		recorder := new(bytes.Buffer)
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) {
+				if b[0] == 0x2 {
+					n, err := recorder.Write(b)
+					wait <- struct{}{}
+					<-wait
+					time.Sleep(time.Microsecond * 10)
+					return n, err
+				}
+				return recorder.Write(b)
+			},
+			doClose: func() error { return nil }}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+		handler.Play(bytes.NewBuffer(expectedContent))
+		<-wait
+		raw1 := recorder.Bytes()
+		wait <- struct{}{}
+		handler.Stop()
+		raw2 := recorder.Bytes()
+		assert.Equal(expectedContent[:2], raw1, "Wrong content at the pause point")
+		assert.True(len(raw2) >= len(raw1), "Second snapshot too short.")
+		assert.True(len(raw2) < len(expectedContent), "Second snapshot too Long.")
+		assert.Equal(expectedContent[:len(raw2)], raw2, "Wrong content of second snapshot")
+	})
+	t.Run("handle skip track", func(t *testing.T) {
+		expectedContent1 := []byte{0x1, 0x2, 0x3, 0x4}
+		expectedContent2 := []byte{0x5, 0x6, 0x7, 0x8}
+		wait := make(chan struct{})
+		handler := New()
+		recorder := new(bytes.Buffer)
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) {
+				if b[0] == 0x2 {
+					n, err := recorder.Write(b)
+					wait <- struct{}{}
+					<-wait
+					time.Sleep(time.Microsecond * 10)
+					return n, err
+				}
+				return recorder.Write(b)
+			},
+			doClose: func() error { return nil }}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+		handler.Play(bytes.NewBuffer(expectedContent1))
+		<-wait
+		raw1 := recorder.Bytes()
+		go handler.Play(bytes.NewBuffer(expectedContent2))
+		wait <- struct{}{}
+		time.Sleep(time.Microsecond * 10)
+		<-handler.FinishedChan
+		raw2 := recorder.Bytes()
+		expectedFinalContent := expectedContent1[:len(raw1)]
+		expectedFinalContent = append(expectedFinalContent, expectedContent2...)
+		assert.Equal(expectedContent1[:2], raw1, "Wrong content at the pause point")
+		assert.Equal(expectedFinalContent, raw2, "Incorrect content returned.")
+	})
+
+	t.Run("handle output stream error", func(t *testing.T) {
+		content := "some content"
+		expectedError := errors.New("exepected error")
+		makeOutputStream = func() (OutputStream, error) { return nil, expectedError }
+		steam := bytes.NewBuffer([]byte(content))
+		handler := New()
+		err := handler.Play(steam)
+		assert.Equal(expectedError, err, "Incorrect error returned.")
+	})
+
+	t.Run("handle write error", func(t *testing.T) {
+		content := "some content"
+		expectedError := errors.New("exepected error")
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) { return 0, expectedError },
+			doClose: func() error { return nil },
+		}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+		handler := New()
+		handler.Play(bytes.NewBuffer([]byte(content)))
+		err := <-handler.ErrChan
+		assert.Equal(expectedError, err, "Incorrect error returned.")
+	})
+
+	t.Run("handle read error", func(t *testing.T) {
+		content := "some content"
+		expectedError := errors.New("exepected error")
+		recorder := new(bytes.Buffer)
+		outStream := &mockOutStream{
+			doWrite: func(b []byte) (int, error) { return recorder.Write(b) },
+			doClose: func() error { return nil },
+		}
+		makeOutputStream = func() (OutputStream, error) { return outStream, nil }
+
+		errReader := &controlledReader{err: expectedError}
+		newDecoder = func(r *io.Reader) io.Reader { return errReader }
+
+		handler := New()
+		handler.Play(bytes.NewBuffer([]byte(content)))
+		err := <-handler.ErrChan
+		assert.Equal(expectedError, err, "Incorrect error returned.")
+	})
+}
+
+type mockOutStream struct {
+	doWrite func([]byte) (int, error)
+	doClose func() error
+}
+
+func (m *mockOutStream) Write(b []byte) (int, error) {
+	return m.doWrite(b)
+}
+
+func (m *mockOutStream) CloseStream() error {
+	return m.doClose()
+}
+
+type controlledReader struct {
+	err error
+}
+
+func (c *controlledReader) Read(out []byte) (int, error) {
+	return 0, c.err
+}

--- a/player.go
+++ b/player.go
@@ -253,6 +253,7 @@ func (p *Player) playerLoop() {
 				continue
 			}
 			p.playNextInQueue(p.queue.popSong)
+			songStart = time.Now()
 			pausedDuration = time.Duration(0)
 		case <-p.closeChan:
 			return

--- a/player.go
+++ b/player.go
@@ -1,0 +1,267 @@
+// Copyright (c) 2018 Joakim Kennedy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package jamsonic
+
+import (
+	"io"
+	"sync"
+)
+
+// State is the state the player can be in.
+type State int8
+
+const (
+	// Stopped is the state when the player is not playing anything.
+	Stopped State = iota
+	// Playing is the state when the player is playing a stream.
+	Playing
+	// Paused is the state when the player has been paused.
+	Paused
+)
+
+type playqueue struct {
+	array []*Track
+}
+
+/*func newQueue(tracks []*Track) *playqueue {
+	return &playqueue{array: tracks}
+}*/
+
+// nextSong returns the next song in the play queue.
+func (q *playqueue) nextSong() *Track {
+	if len(q.array) >= 1 {
+		return q.array[0]
+	}
+	return nil
+}
+
+// popSong returns the next song in the play queue and removes it from the queue.
+func (q *playqueue) popSong() *Track {
+	track := q.nextSong()
+	tmp := make([]*Track, len(q.array)-1)
+	copy(tmp, q.array[1:])
+	q.array = tmp
+	return track
+}
+
+func (q *playqueue) pushSong(t *Track) {
+	tmp := make([]*Track, len(q.array)+1)
+	tmp[0] = t
+	for i, tr := range q.array {
+		tmp[i+1] = tr
+	}
+	q.array = tmp
+}
+
+func NewPlayer(p Provider, h StreamHandler) *Player {
+	player := &Player{
+		Handler:   h,
+		Provider:  p,
+		Error:     make(chan error),
+		closeChan: make(chan struct{}),
+		playChan:  make(chan struct{}),
+		pauseChan: make(chan struct{}),
+		nextChan:  make(chan struct{}),
+		prevChan:  make(chan struct{}),
+		stopChan:  make(chan struct{}),
+		played:    &playqueue{array: make([]*Track, 0)},
+	}
+	go player.playerLoop()
+	return player
+}
+
+type Player struct {
+	Handler       StreamHandler
+	Provider      Provider
+	Error         chan error
+	queue         *playqueue
+	played        *playqueue
+	queueMu       sync.RWMutex
+	currentTrack  *Track
+	currentStream io.ReadCloser
+	state         State
+	stateMu       sync.RWMutex
+	playChan      chan struct{}
+	stopChan      chan struct{}
+	pauseChan     chan struct{}
+	nextChan      chan struct{}
+	prevChan      chan struct{}
+	closeChan     chan struct{}
+}
+
+func (p *Player) Play() {
+	p.playChan <- struct{}{}
+}
+
+func (p *Player) Pause() {
+	p.pauseChan <- struct{}{}
+}
+
+func (p *Player) Next() {
+	p.nextChan <- struct{}{}
+}
+
+func (p *Player) Previous() {
+	p.prevChan <- struct{}{}
+}
+
+func (p *Player) Stop() {
+	p.stopChan <- struct{}{}
+}
+
+// GetCurrentState returns the player's current internal state.
+func (p *Player) GetCurrentState() State {
+	p.stateMu.RLock()
+	defer p.stateMu.RUnlock()
+	return p.state
+}
+
+// CreatePlayQueue creates a new list with queued tracks.
+func (p *Player) CreatePlayQueue(tracks []*Track) {
+	p.queue = &playqueue{array: tracks}
+}
+
+// NextTrack returns the next track in the play queue.
+func (p *Player) NextTrack() *Track {
+	return p.queue.nextSong()
+}
+
+// CurrentTrack returns the current playing or paused track.
+func (p *Player) CurrentTrack() *Track {
+	return p.currentTrack
+}
+
+func (p *Player) playerLoop() {
+	finished := p.Handler.Finished()
+	for {
+		select {
+		case <-p.playChan:
+			status := p.changeState(Playing)
+			if status == Paused {
+				p.Handler.Continue()
+				continue
+			}
+			p.playNextInQueue(p.queue.popSong)
+		case <-p.pauseChan:
+			p.Handler.Pause()
+			p.changeState(Paused)
+		case <-p.stopChan:
+			if p.GetCurrentState() == Stopped {
+				continue
+			}
+			if p.currentTrack != nil {
+				p.queue.pushSong(p.currentTrack)
+			}
+			p.stopPlaying()
+		case <-p.nextChan:
+			state := p.GetCurrentState()
+			if state == Stopped {
+				continue
+			}
+			if state == Paused {
+				p.changeState(Playing)
+			}
+			if p.currentTrack != nil {
+				p.played.pushSong(p.currentTrack)
+			}
+			p.playNextInQueue(p.queue.popSong)
+		case <-p.prevChan:
+			state := p.GetCurrentState()
+			if state == Stopped {
+				continue
+			}
+			if p.played.nextSong() == nil {
+				continue
+			}
+			p.queue.pushSong(p.currentTrack)
+			p.playNextInQueue(p.played.popSong)
+		case <-finished:
+			if p.currentTrack != nil {
+				p.played.pushSong(p.currentTrack)
+			}
+			if p.NextTrack() == nil {
+				p.stopPlaying()
+				continue
+			}
+			p.playNextInQueue(p.queue.popSong)
+		case <-p.closeChan:
+			return
+		}
+	}
+}
+
+func (p *Player) Close() {
+	p.closeChan <- struct{}{}
+}
+
+func (p *Player) playNextInQueue(getTrack func() *Track) {
+	p.queueMu.Lock()
+	p.currentTrack = getTrack()
+	p.queueMu.Unlock()
+	if p.currentStream != nil {
+		p.currentStream.Close()
+	}
+	stream, err := p.Provider.GetStream(p.currentTrack.ID)
+	p.currentStream = stream
+	if err != nil {
+		handleStreamError(p, err)
+	}
+	err = p.Handler.Play(stream)
+	if err != nil {
+		handleStreamError(p, err)
+	}
+}
+
+func (p *Player) stopPlaying() {
+	p.Handler.Stop()
+	p.currentStream.Close()
+	p.currentStream = nil
+	p.currentTrack = nil
+	p.changeState(Stopped)
+}
+
+// changeState changes the state to the new but also returns the previous state.
+func (p *Player) changeState(s State) State {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	status := p.state
+	p.state = s
+	return status
+}
+
+func handleStreamError(p *Player, err error) {
+	go func() {
+		p.Error <- err
+	}()
+	p.changeState(Stopped)
+	p.queueMu.Lock()
+	p.queue.pushSong(p.currentTrack)
+	p.queueMu.Unlock()
+	p.currentStream.Close()
+}
+
+type StreamHandler interface {
+	Finished() <-chan struct{}
+	Play(io.Reader) error
+	Stop()
+	Pause()
+	Continue()
+}

--- a/player_test.go
+++ b/player_test.go
@@ -1,0 +1,407 @@
+// Copyright (c) 2018 Joakim Kennedy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package jamsonic
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlayControl(t *testing.T) {
+	assert := assert.New(t)
+	player, _, _, _ := getPlayer()
+	tracks := []*Track{
+		&Track{ID: "1"},
+		&Track{ID: "2"},
+		&Track{ID: "3"},
+		&Track{ID: "4"},
+	}
+	player.CreatePlayQueue(tracks)
+
+	t.Run("get state", func(t *testing.T) {
+		assert.Equal(Stopped, player.GetCurrentState())
+	})
+
+	t.Run("change current state to playing", func(t *testing.T) {
+		player.state = Playing
+		assert.Equal(Playing, player.GetCurrentState(), "Should be set to playing")
+	})
+
+	t.Run("change current state to paused", func(t *testing.T) {
+		player.state = Paused
+		assert.Equal(Paused, player.GetCurrentState(), "Should be set to paused")
+	})
+
+	t.Run("change current state to stopped", func(t *testing.T) {
+		player.state = Stopped
+		assert.Equal(Stopped, player.GetCurrentState(), "Should be set to stopped")
+	})
+
+	t.Run("current when not playing", func(t *testing.T) {
+		track := player.CurrentTrack()
+		assert.Nil(track, "Track should be nil")
+	})
+
+	t.Run("next track before playing", func(t *testing.T) {
+		track := player.NextTrack()
+		assert.Equal(tracks[0], track, "Should point to first track before playing")
+	})
+
+	player.Close()
+
+	t.Run("Playing", func(t *testing.T) {
+		p, _, provider, handler := getPlayer()
+		p.CreatePlayQueue(tracks)
+
+		// At stop nothing should happen.
+		p.Stop()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(0, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(0, handler.calledStopped, "Wrong number of calls")
+		assert.Equal(Stopped, p.GetCurrentState(), "State should be playing.")
+		assert.Nil(p.CurrentTrack(), "Current track should be nil.")
+		assert.Equal(tracks[0], p.NextTrack(), "1st track should be marked as next")
+
+		p.Play()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(tracks[0].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+
+		// Stop playing
+		p.Stop()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(1, handler.calledStopped, "Wrong number of calls")
+		assert.Equal(Stopped, p.GetCurrentState(), "State should be playing.")
+		assert.Nil(p.CurrentTrack(), "Current track should be nil.")
+		assert.Equal(tracks[0], p.NextTrack(), "1st track should be marked as next")
+
+		p.Close()
+	})
+
+	t.Run("Playing", func(t *testing.T) {
+		p, finished, provider, handler := getPlayer()
+		p.CreatePlayQueue(tracks)
+		p.Play()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(tracks[0].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+
+		// Second track.
+		time.Sleep(time.Millisecond * 200)
+		finished <- struct{}{}
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(2, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(tracks[1].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(tracks[1], p.CurrentTrack(), "2nd track not playing")
+		assert.Equal(tracks[2], p.NextTrack(), "3rd track should be marked as next")
+		assert.Equal(tracks[0], p.played.nextSong(), "1st track should be first in the played list")
+
+		// Third track
+		time.Sleep(time.Millisecond * 200)
+		finished <- struct{}{}
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(3, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(tracks[2].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(tracks[2], p.CurrentTrack(), "3rd track not playing")
+		assert.Equal(tracks[3], p.NextTrack(), "4th track should be marked as next")
+		assert.Equal(tracks[1], p.played.nextSong(), "2nd track should be first in the played list")
+
+		// 4th track
+		time.Sleep(time.Millisecond * 200)
+		finished <- struct{}{}
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(4, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(tracks[3].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(tracks[3], p.CurrentTrack(), "4th track not playing")
+		assert.Nil(p.NextTrack(), "Nil should be returned for next track")
+		assert.Equal(tracks[2], p.played.nextSong(), "3rd track should be first in the played list")
+
+		// Stop when queue is empty
+		time.Sleep(time.Millisecond * 200)
+		finished <- struct{}{}
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Stopped, p.GetCurrentState(), "State should be stopped.")
+		assert.Nil(p.CurrentTrack(), "Current track should be nil")
+		assert.Nil(p.NextTrack(), "Nil should be returned for next track")
+		assert.Equal(tracks[3], p.played.nextSong(), "4th track should be first in the played list")
+
+		p.Close()
+	})
+
+	t.Run("Pausing", func(t *testing.T) {
+		p, _, provider, handler := getPlayer()
+		p.CreatePlayQueue(tracks)
+		p.Play()
+
+		// Ensure initial state is correct.
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(tracks[0].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(0, handler.calledPause, "Wrong number of calls")
+		assert.Equal(0, handler.calledContrinue, "Wrong number of calls")
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+
+		// Pause during the first track.
+		p.Pause()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Paused, p.GetCurrentState(), "State should be paused.")
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(1, handler.calledPause, "Wrong number of calls")
+		assert.Equal(0, handler.calledContrinue, "Wrong number of calls")
+		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+
+		// Continue
+		p.Play()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "State should be paused.")
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(1, handler.calledPause, "Wrong number of calls")
+		assert.Equal(1, handler.calledContrinue, "Wrong number of calls")
+		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+
+		p.Close()
+	})
+
+	t.Run("Song skipping", func(t *testing.T) {
+		p, _, provider, handler := getPlayer()
+		p.CreatePlayQueue(tracks)
+
+		// Skipping during stopped shouldn't do anything.
+		assert.Equal(Stopped, p.GetCurrentState(), "Wrong state")
+		p.Next()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Stopped, p.GetCurrentState(), "Wrong state")
+		assert.Nil(p.CurrentTrack(), "Wrong track")
+		assert.Equal(tracks[0], p.NextTrack(), "1st track should be marked as next")
+
+		// Ensure initial state is correct.
+		p.Play()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(tracks[0].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(0, handler.calledPause, "Wrong number of calls")
+		assert.Equal(0, handler.calledContrinue, "Wrong number of calls")
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+
+		// Skip to next track.
+		p.Next()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(2, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(0, handler.calledPause, "Wrong number of calls")
+		assert.Equal(0, handler.calledContrinue, "Wrong number of calls")
+		assert.Equal(tracks[1].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(tracks[1], p.CurrentTrack(), "2nd track not playing")
+		assert.Equal(tracks[2], p.NextTrack(), "3rd track should be marked as next")
+		assert.Equal(tracks[0], p.played.nextSong(), "1st track should be first in the played list")
+
+		// Skip from paused state.
+		p.Pause()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Paused, p.GetCurrentState(), "Wrong state")
+		p.Next()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(3, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(1, handler.calledPause, "Wrong number of calls")
+		assert.Equal(0, handler.calledContrinue, "Wrong number of calls")
+		assert.Equal(tracks[2].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(tracks[2], p.CurrentTrack(), "3rd track not playing")
+		assert.Equal(tracks[3], p.NextTrack(), "4th track should be marked as next")
+		assert.Equal(tracks[1], p.played.nextSong(), "2nd track should be first in the played list")
+
+		p.Close()
+	})
+
+	t.Run("Song reverse skipping", func(t *testing.T) {
+		p, _, provider, handler := getPlayer()
+		p.CreatePlayQueue(tracks)
+
+		// Skipping back during stopped shouldn't do anything.
+		assert.Equal(Stopped, p.GetCurrentState(), "Wrong state")
+		p.Previous()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Stopped, p.GetCurrentState(), "Wrong state")
+		assert.Nil(p.CurrentTrack(), "Wrong track")
+		assert.Equal(tracks[0], p.NextTrack(), "1st track should be marked as next")
+
+		// Skipping if no songs have been played shouldn't do anything.
+		p.Play()
+		p.Previous()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "Wrong state")
+		assert.Equal(tracks[0].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(tracks[0], p.CurrentTrack(), "1st track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+		assert.Nil(p.played.nextSong(), "Nil should be returned for played.")
+
+		// Ensure initial state is correct. First track in played list.
+		p.Next()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(tracks[1].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(2, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(0, handler.calledPause, "Wrong number of calls")
+		assert.Equal(0, handler.calledContrinue, "Wrong number of calls")
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(tracks[1], p.CurrentTrack(), "2nd track not playing")
+		assert.Equal(tracks[2], p.NextTrack(), "3rd track should be marked as next")
+		assert.Equal(tracks[0], p.played.nextSong(), "1st track should be first in the played list")
+
+		// Back to prev track.
+		p.Previous()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "State should be playing.")
+		assert.Equal(3, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(0, handler.calledPause, "Wrong number of calls")
+		assert.Equal(0, handler.calledContrinue, "Wrong number of calls")
+		assert.Equal(tracks[0].ID, provider.streamID, "Wrong track id called")
+		assert.Equal(tracks[0], p.CurrentTrack(), "1st track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+		assert.Nil(p.played.nextSong(), "Nil should be returned for played.")
+
+		p.Close()
+	})
+}
+
+func getPlayer() (*Player, chan struct{}, *mockProvider, *mockStreaHandler) {
+	finishedChan := make(chan struct{})
+
+	provider := &mockProvider{
+		doGetStream: func(id string) (io.ReadCloser, error) {
+			return &recorder{streamID: id}, nil
+		},
+	}
+	handler := &mockStreaHandler{
+		doFinished: func() <-chan struct{} { return finishedChan },
+		doPlay:     func(io.Reader) error { return nil },
+		doStop:     func() {},
+		doPause:    func() {},
+		doContinue: func() {},
+	}
+	return NewPlayer(provider, handler), finishedChan, provider, handler
+}
+
+type recorder struct {
+	streamID string
+}
+
+func (r *recorder) Read([]byte) (int, error) {
+	return 0, nil
+}
+
+func (r *recorder) Close() error {
+	return nil
+}
+
+type mockStreaHandler struct {
+	doFinished      func() <-chan struct{}
+	doPlay          func(io.Reader) error
+	calledPlay      int
+	doStop          func()
+	calledStopped   int
+	doPause         func()
+	calledPause     int
+	doContinue      func()
+	calledContrinue int
+}
+
+func (m *mockStreaHandler) Finished() <-chan struct{} {
+	return m.doFinished()
+}
+
+func (m *mockStreaHandler) Play(r io.Reader) error {
+	m.calledPlay += 1
+	return m.doPlay(r)
+}
+
+func (m *mockStreaHandler) Stop() {
+	m.calledStopped += 1
+	m.doStop()
+}
+
+func (m *mockStreaHandler) Pause() {
+	m.calledPause += 1
+	m.doPause()
+}
+
+func (m *mockStreaHandler) Continue() {
+	m.calledContrinue += 1
+	m.doContinue()
+}
+
+type mockProvider struct {
+	streamID              string
+	doListTracks          func() ([]*Track, error)
+	doFetchLibrary        func() ([]*Artist, error)
+	doGetTrackInfo        func(trackID string) (*Track, error)
+	doGetStream           func(songID string) (io.ReadCloser, error)
+	doListPlaylists       func() ([]*Playlist, error)
+	doListPlaylistEntries func() ([]*PlaylistEntry, error)
+	doGetProvider         func() MusicProvider
+}
+
+func (m *mockProvider) ListTracks() ([]*Track, error) {
+	return m.doListTracks()
+}
+
+func (m *mockProvider) FetchLibrary() ([]*Artist, error) {
+	return m.doFetchLibrary()
+}
+
+func (m *mockProvider) GetTrackInfo(trackID string) (*Track, error) {
+	return m.doGetTrackInfo(trackID)
+}
+
+func (m *mockProvider) GetStream(songID string) (io.ReadCloser, error) {
+	m.streamID = songID
+	return m.doGetStream(songID)
+}
+
+func (m *mockProvider) ListPlaylists() ([]*Playlist, error) {
+	return m.doListPlaylists()
+}
+
+func (m *mockProvider) ListPlaylistEntries() ([]*PlaylistEntry, error) {
+	return m.ListPlaylistEntries()
+}
+
+func (m *mockProvider) GetProvider() MusicProvider {
+	return m.doGetProvider()
+}

--- a/player_test.go
+++ b/player_test.go
@@ -370,7 +370,7 @@ func getPlayer() (*Player, chan struct{}, *mockProvider, *mockStreaHandler) {
 		doPause:    func() {},
 		doContinue: func() {},
 	}
-	return NewPlayer(provider, handler), finishedChan, provider, handler
+	return NewPlayer(provider, handler, nil, 0), finishedChan, provider, handler
 }
 
 type recorder struct {

--- a/player_test.go
+++ b/player_test.go
@@ -228,6 +228,30 @@ func TestPlayControl(t *testing.T) {
 		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
 		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
 
+		// Pause during the first track.
+		p.Pause()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Paused, p.GetCurrentState(), "State should be paused.")
+		calledMu.RLock()
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(2, handler.calledPause, "Wrong number of calls")
+		assert.Equal(1, handler.calledContrinue, "Wrong number of calls")
+		calledMu.RUnlock()
+		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+
+		// Continue with a second call to pause.
+		p.Pause()
+		time.Sleep(time.Millisecond * 200)
+		assert.Equal(Playing, p.GetCurrentState(), "State should be paused.")
+		calledMu.RLock()
+		assert.Equal(1, handler.calledPlay, "Wrong number of calls")
+		assert.Equal(2, handler.calledPause, "Wrong number of calls")
+		assert.Equal(2, handler.calledContrinue, "Wrong number of calls")
+		calledMu.RUnlock()
+		assert.Equal(tracks[0], p.CurrentTrack(), "First track not playing")
+		assert.Equal(tracks[1], p.NextTrack(), "2nd track should be marked as next")
+
 		p.Close()
 	})
 


### PR DESCRIPTION
Complete rewrite of the player logic. Fixes #5 

* Player is part of the main package.
* A StreamHandler was added which does the decoding and sends the output to a writer.
* The new player is disabled by default but can be used by the `-experimental` flag.